### PR TITLE
Remove `grafana-operator` from `grafana-opscenter` chart

### DIFF
--- a/charts/grafana-opscenter/Chart.yaml
+++ b/charts/grafana-opscenter/Chart.yaml
@@ -12,10 +12,6 @@ maintainers:
 - name: appscode
   email: support@appscode.com
 dependencies:
-- name: grafana-operator
-  repository: file://../grafana-operator
-  condition: grafana-operator.enabled
-  version: v0.0.2
 - name: grafana-ui-server
   repository: file://../grafana-ui-server
   condition: grafana-ui-server.enabled


### PR DESCRIPTION
Signed-off-by: Masudur Rahman <masud@appscode.com>