### PR TITLE
For grouped alerts, list firing alerts before resolved ones instead of displaying a randomly shuffled list.

### DIFF
--- a/charts/monitoring-operator/files/alertmanager/email.html.tmpl
+++ b/charts/monitoring-operator/files/alertmanager/email.html.tmpl
@@ -68,7 +68,41 @@
       <th style="width: 24%;">Labels</th>
       <th style="width: 50%;">Content</th>
     </tr>
-    {{- range .Alerts }}
+    {{- range .Alerts.Firing }}
+    <tr>
+      <td style="width: 10%;">
+        {{- if eq .Status "firing" -}}
+        <span class="status-firing">FIRING</span>
+        {{- else if eq .Status "resolved" -}}
+        <span class="status-resolved">RESOLVED</span>
+        {{- else -}}
+        {{ .Status | toUpper }}
+        {{- end -}}
+        {{- if .Annotations.runbook_url }}
+        <div style="margin-top:8px;"><a href="{{ .Annotations.runbook_url }}">Runbook</a></div>
+        {{- end }}
+      </td>
+      <td style="width: 16%;">{{ .StartsAt }}</td>
+      <td style="width: 24%;">
+        {{- range .Labels.SortedPairs }}
+        {{- if ne .Name "instance" }}
+        <div><strong>{{ .Name }}</strong>: {{ .Value }}</div>
+        {{- end }}
+        {{- end }}
+      </td>
+      <td style="width: 50%;">
+        {{- if .Annotations.summary }}
+        <div><strong>Summary</strong></div>
+        <pre>{{ .Annotations.summary }}</pre>
+        {{- end }}
+        {{- if .Annotations.description }}
+        <div style="margin-top:8px;"><strong>Description</strong></div>
+        <pre>{{ .Annotations.description }}</pre>
+        {{- end }}
+      </td>
+    </tr>
+    {{- end }}
+    {{- range .Alerts.Resolved }}
     <tr>
       <td style="width: 10%;">
         {{- if eq .Status "firing" -}}

--- a/charts/monitoring-operator/files/alertmanager/email.text.tmpl
+++ b/charts/monitoring-operator/files/alertmanager/email.text.tmpl
@@ -1,5 +1,22 @@
 Alert Details:
-{{- range .Alerts }}
+{{- range .Alerts.Firing }}
+- Status: {{ .Status | toUpper }}
+  Alertname: {{ .Labels.alertname }}
+  Namespace: {{ or .Labels.namespace .Labels.app_namespace "default" }}
+  Job: {{ or .Labels.job "unknown" }}
+  Starts At: {{ .StartsAt }}
+  {{- if .Annotations.summary }}
+  Summary: {{ .Annotations.summary }}
+  {{- end }}
+  {{- if .Annotations.description }}
+  Description: {{ .Annotations.description }}
+  {{- end }}
+  Labels:
+  {{- range .Labels.SortedPairs }}
+    - {{ .Name }}: {{ .Value }}
+  {{- end }}
+{{- end }}
+{{- range .Alerts.Resolved }}
 - Status: {{ .Status | toUpper }}
   Alertname: {{ .Labels.alertname }}
   Namespace: {{ or .Labels.namespace .Labels.app_namespace "default" }}


### PR DESCRIPTION
Before:
<img width="1656" height="838" alt="image" src="https://github.com/user-attachments/assets/1ae20647-b887-40d8-89da-33b404c219af" />

---

After:
<img width="1662" height="854" alt="image" src="https://github.com/user-attachments/assets/8dcd0609-a051-4c05-afaf-cf23ce1ad246" />
