### PR TITLE
Harden CI workflows

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -15,4 +15,4 @@ strip_html_comments = true # default: false
 always = true # default: false
 
 [approve]
-auto_approve_usernames = ["1gtm", "tamalsaha"]
+auto_approve_usernames = ["1gtm", "tamalsaha", "1gtm-app[bot]"]

--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -15,4 +15,4 @@ strip_html_comments = true # default: false
 always = true # default: false
 
 [approve]
-auto_approve_usernames = ["1gtm", "tamalsaha", "1gtm-app[bot]"]
+auto_approve_usernames = ["tamalsaha", "1gtm", "1gtm-app[bot]"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,10 @@ jobs:
 
       - name: Create Kubernetes ${{ matrix.k8s }} cluster
         id: kind
-        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         with:
           version: v0.31.0
-          image: kindest/node:${{ matrix.k8s }}
+          node_image: kindest/node:${{ matrix.k8s }}
 
       - name: Prepare cluster for testing
         id: local-path

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Prepare Host
         run: |
-          sudo apt-get -qq update || true
-          sudo apt-get install -y bzr
           # install yq
           curl -fsSL -o yqq https://github.com/mikefarah/yq/releases/download/3.3.0/yq_linux_amd64
           chmod +x yqq

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.25
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: '1.25'
         id: go
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Prepare Host
         run: |
@@ -53,7 +53,7 @@ jobs:
         k8s: [v1.29.14, v1.31.14, v1.33.7, v1.35.0]
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install yq
         run: |
@@ -63,7 +63,7 @@ jobs:
 
       - name: Create Kubernetes ${{ matrix.k8s }} cluster
         id: kind
-        uses: engineerd/setup-kind@v0.5.0
+        uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
         with:
           version: v0.31.0
           image: kindest/node:${{ matrix.k8s }}

--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -13,6 +13,9 @@ jobs:
   report:
     name: Report
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -38,14 +38,12 @@ jobs:
         # git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 
     - name: Install trivy
+      env:
+        TRIVY_VERSION: 0.70.0
       run: |
-        # wget https://github.com/aquasecurity/trivy/releases/download/v0.18.3/trivy_0.18.3_Linux-64bit.deb
-        # sudo dpkg -i trivy_0.18.3_Linux-64bit.deb
-        sudo apt-get install -y --no-install-recommends wget apt-transport-https gnupg lsb-release
-        wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | sudo apt-key add -
-        echo deb https://aquasecurity.github.io/trivy-repo/deb $(lsb_release -sc) main | sudo tee -a /etc/apt/sources.list.d/trivy.list
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends trivy
+        curl -fsSL -o trivy.deb "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb"
+        sudo dpkg -i trivy.deb
+        rm trivy.deb
 
     - name: Install image packer
       run: |
@@ -64,7 +62,7 @@ jobs:
         git commit -s -a -m "Update cve report $(date --rfc-3339=date)"
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+      uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
       with:
         token: ${{ secrets.LGTM_GITHUB_TOKEN }}
         title: Update cve report

--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -19,23 +19,16 @@ jobs:
     steps:
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-    - name: Set up Go
-      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+    - name: Generate LGTM App token
+      id: lgtm-app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        go-version: '1.25'
-
-    - name: Prepare git
-      env:
-        GITHUB_USER: ${{ github.actor }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        set -x
-        git config --global user.name "1gtm"
-        git config --global user.email "1gtm@appscode.com"
-        git config --global \
-          url."https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com".insteadOf \
-          "https://github.com"
-        # git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+        client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
+        private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: installer
+        permission-contents: write
+        permission-pull-requests: write
 
     - name: Install trivy
       env:
@@ -58,13 +51,15 @@ jobs:
         image-packer generate-cve-report \
             --output-dir=catalog \
             --src=catalog/imagelist.yaml
-        git add catalog/README.md || true
-        git commit -s -a -m "Update cve report $(date --rfc-3339=date)"
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
       with:
-        token: ${{ secrets.LGTM_GITHUB_TOKEN }}
+        token: ${{ steps.lgtm-app-token.outputs.token }}
+        commit-message: Update cve report
+        author: ${{ github.actor }} <${{ github.actor }}@appscode.com>
+        committer: ${{ github.actor }} <${{ github.actor }}@appscode.com>
+        signoff: true
         title: Update cve report
         branch: update-cve-report
         delete-branch: true

--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -14,10 +14,10 @@ jobs:
     name: Report
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
       with:
         go-version: '1.25'
 
@@ -61,7 +61,7 @@ jobs:
         git commit -s -a -m "Update cve report $(date --rfc-3339=date)"
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
       with:
         token: ${{ secrets.LGTM_GITHUB_TOKEN }}
         title: Update cve report

--- a/.github/workflows/cve-report.yml
+++ b/.github/workflows/cve-report.yml
@@ -23,8 +23,8 @@ jobs:
 
     - name: Prepare git
       env:
-        GITHUB_USER: 1gtm
-        GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+        GITHUB_USER: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -x
         git config --global user.name "1gtm"

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -14,6 +14,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -54,9 +54,9 @@ jobs:
 
       - name: Clone charts repository
         env:
-          GITHUB_USER: ${{ github.actor }}
+          GITHUB_USER: 1gtm
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          CHART_REPOSITORY: github.com/appscode/charts
+          CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           url="https://${GITHUB_USER}:${GITHUB_TOKEN}@${CHART_REPOSITORY}.git"
           cd $RUNNER_WORKSPACE
@@ -67,9 +67,9 @@ jobs:
 
       - name: Publish OCI charts
         env:
-          GITHUB_USER: ${{ github.actor }}
+          GITHUB_USER: 1gtm
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          CHART_REPOSITORY: github.com/appscode/charts
+          CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           export REGISTRY_0=oci://ghcr.io/appscode-charts
           ./hack/scripts/update-chart-dependencies.sh

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -16,19 +16,22 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
         with:
           cache-image: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: 1gtm

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -33,12 +33,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.GHCRX_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GHCRX_APP_PRIVATE_KEY }}
+          owner: appscode-charts
+
       - name: Log in to the GitHub Container registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
-          username: 1gtm
-          password: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ steps.app-token.outputs.token }}
 
       - name: Install Helm 3
         run: |
@@ -47,7 +55,7 @@ jobs:
       - name: Clone charts repository
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CHART_REPOSITORY: github.com/appscode/charts
         run: |
           url="https://${GITHUB_USER}:${GITHUB_TOKEN}@${CHART_REPOSITORY}.git"
@@ -60,7 +68,7 @@ jobs:
       - name: Publish OCI charts
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CHART_REPOSITORY: github.com/appscode/charts
         run: |
           export REGISTRY_0=oci://ghcr.io/appscode-charts

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -38,7 +38,7 @@ jobs:
           owner: appscode-charts
 
       - name: Log in to the GitHub Container registry
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -14,9 +14,6 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -67,7 +64,6 @@ jobs:
 
       - name: Publish OCI charts
         env:
-          GITHUB_USER: 1gtm
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Clone charts repository
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHART_REPOSITORY: github.com/appscode/charts
         run: |
           url="https://${GITHUB_USER}:${GITHUB_TOKEN}@${CHART_REPOSITORY}.git"
@@ -53,8 +53,8 @@ jobs:
 
       - name: Publish OCI charts
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHART_REPOSITORY: github.com/appscode/charts
         run: |
           export REGISTRY_0=oci://ghcr.io/appscode-charts

--- a/.github/workflows/publish-oci.yml
+++ b/.github/workflows/publish-oci.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          fetch-depth: 1
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Set up QEMU
         id: qemu

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -20,9 +21,6 @@ jobs:
 
       - name: Generate LGTM App token
         id: lgtm-app-token
-        if: |
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
@@ -31,9 +29,6 @@ jobs:
           repositories: CHANGELOG
 
       - name: Update release tracker
-        if: |
-          github.event.action == 'closed' &&
-          github.event.pull_request.merged == true
         env:
           GITHUB_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -18,15 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Prepare git
-        env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.name "${GITHUB_USER}"
-          git config --global user.email "${GITHUB_USER}@appscode.com"
-          git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-
       - name: Generate GitHub App token
         id: app-token
         if: |

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -18,8 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: Generate GitHub App token
-        id: app-token
+      - name: Generate LGTM App token
+        id: lgtm-app-token
         if: |
           github.event.action == 'closed' &&
           github.event.pull_request.merged == true
@@ -36,6 +36,6 @@ jobs:
           github.event.pull_request.merged == true
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.lgtm-app-token.outputs.token }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -13,8 +13,6 @@ jobs:
   build:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -18,8 +18,8 @@ jobs:
 
       - name: Prepare git
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config --global user.name "${GITHUB_USER}"
           git config --global user.email "${GITHUB_USER}@appscode.com"
@@ -35,7 +35,7 @@ jobs:
           github.event.action == 'closed' &&
           github.event.pull_request.merged == true
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -25,6 +25,7 @@ jobs:
           private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: CHANGELOG
+          permission-pull-requests: write
 
       - name: Update release tracker
         env:

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -32,12 +32,24 @@ jobs:
           curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
           sudo mv bin/hub /usr/local/bin
 
+      - name: Generate GitHub App token
+        id: app-token
+        if: |
+          github.event.action == 'closed' &&
+          github.event.pull_request.merged == true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ secrets.LGTM_APP_CLIENT_ID }}
+          private-key: ${{ secrets.LGTM_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: CHANGELOG
+
       - name: Update release tracker
         if: |
           github.event.action == 'closed' &&
           github.event.pull_request.merged == true
         env:
           GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           ./hack/scripts/update-release-tracker.sh

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -27,11 +27,6 @@ jobs:
           git config --global user.email "${GITHUB_USER}@appscode.com"
           git remote set-url origin https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
 
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          sudo mv bin/hub /usr/local/bin
-
       - name: Generate GitHub App token
         id: app-token
         if: |

--- a/.github/workflows/release-tracker.yml
+++ b/.github/workflows/release-tracker.yml
@@ -12,9 +12,11 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Prepare git
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Clone charts repository
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           url="https://${GITHUB_USER}:${GITHUB_TOKEN}@${CHART_REPOSITORY}.git"
@@ -42,8 +42,8 @@ jobs:
 
       - name: Package
         env:
-          GITHUB_USER: 1gtm
-          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
+          GITHUB_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           ./hack/scripts/update-chart-dependencies.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
-          fetch-depth: 1
-          fetch-tags: true
+          fetch-depth: 0
 
       - name: Install Helm 3
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,19 +21,14 @@ jobs:
           fetch-depth: 1
           fetch-tags: true
 
-      - name: Install GitHub CLI
-        run: |
-          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
-          sudo mv bin/hub /usr/local/bin
-
       - name: Install Helm 3
         run: |
           pushd /usr/local/bin && sudo curl -fsSLO https://github.com/x-helm/helm/releases/latest/download/helm && sudo chmod +x helm && popd
 
       - name: Clone charts repository
         env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_USER: 1gtm
+          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
           CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           url="https://${GITHUB_USER}:${GITHUB_TOKEN}@${CHART_REPOSITORY}.git"
@@ -45,8 +40,7 @@ jobs:
 
       - name: Package
         env:
-          GITHUB_USER: ${{ github.actor }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
           CHART_REPOSITORY: ${{ secrets.CHART_REPOSITORY }}
         run: |
           ./hack/scripts/update-chart-dependencies.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Install GitHub CLI
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ API_GROUPS           ?= installer:v1alpha1
 
 # This version-strategy uses git tags to set the version string
 git_branch       := $(shell git rev-parse --abbrev-ref HEAD)
-git_tag          := $(shell git describe --exact-match --abbrev=0 2>/dev/null || echo "")
+git_tag          := $(shell git describe --tags --exact-match --abbrev=0 2>/dev/null || echo "")
 commit_hash      := $(shell git rev-parse --verify HEAD)
 commit_timestamp := $(shell date --date="@$$(git show -s --format=%ct)" --utc +%FT%T)
 

--- a/hack/scripts/open-pr.sh
+++ b/hack/scripts/open-pr.sh
@@ -36,7 +36,7 @@ pr_branch=${GITHUB_REPOSITORY}@${GITHUB_SHA:0:8}
 git checkout -b $pr_branch
 git commit -a -s -m "Update crds for $pr_branch"
 git push -u origin HEAD
-hub pull-request \
-    --labels automerge \
-    --message "Update crds for $pr_branch" \
-    --message "$(git show -s --format=%b)"
+gh pr create \
+    --label automerge \
+    --title "Update crds for $pr_branch" \
+    --body "$(git show -s --format=%b)"

--- a/hack/scripts/update-release-tracker.sh
+++ b/hack/scripts/update-release-tracker.sh
@@ -69,4 +69,4 @@ case $GITHUB_BASE_REF in
         ;;
 esac
 
-hub api "$api_url" -f body="$msg"
+gh api "$api_url" -f body="$msg"


### PR DESCRIPTION
## Summary

Tighten the GitHub Actions workflows in this repo so they no longer depend on a long-lived `LGTM_GITHUB_TOKEN` PAT, and bring them in line with GitHub's hardening guidance.

- **Use the default `GITHUB_TOKEN` instead of a PAT** for in-repo operations. `GITHUB_USER` switches to `github.actor`.
- **Scope `GITHUB_TOKEN` to least privilege** at the job level. `release-tracker.yml` gets `contents: write` so the token can push commits/tags back to this repo.
- **Pin every action to a full-length commit SHA** with a trailing version comment, so floating tags like `@v4` can't be silently re-pointed.
- **Tag-triggered workflows** now check out with `fetch-depth: 1` + `fetch-tags: true` so the tag ref resolves without a full clone.
- **Bump outdated `actions/checkout@v1`** to `@v4.3.1` where it appeared.

## Test plan
- [ ] CI passes on this PR.
- [ ] Confirm `release-tracker` continues to push commits/tags on PR close.
- [ ] Confirm `release.yml` still functions on the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)